### PR TITLE
Port rolling horizon controller to Python with tests

### DIFF
--- a/fcn_stateless.m
+++ b/fcn_stateless.m
@@ -1,0 +1,74 @@
+function scheduleWindows = fcn_stateless(spatBase, spatDurations, spatGreen, horizonTime)
+%FCN_STATELESS Generate green windows using numeric arrays only.
+%   scheduleWindows = fcn_stateless(spatBase, spatDurations, spatGreen,
+%   horizonTime) returns a matrix where each row is
+%       [intersectionId, windowStart, windowEnd]
+%   describing a green window that occurs within the provided horizon.
+%
+%   spatBase      : Kx3 matrix [id, currentPhase, timeToPhaseEnd].
+%   spatDurations : PxK matrix containing phase durations (seconds).
+%   spatGreen     : PxK matrix with 0/1 flags (1 indicates green).
+%   horizonTime   : scalar look-ahead window (seconds).
+
+    if nargin < 4 || isempty(horizonTime)
+        horizonTime = 180;
+    end
+
+    if isempty(spatBase)
+        scheduleWindows = zeros(0, 3);
+        return;
+    end
+
+    numIntersections = size(spatBase, 1);
+    scheduleWindows = zeros(0, 3);
+
+    for idx = 1:numIntersections
+        intersectionId = spatBase(idx, 1);
+        currentPhase = max(1, round(spatBase(idx, 2)));
+        timeRemaining = spatBase(idx, 3);
+
+        durations = spatDurations(:, idx);
+        greenFlags = spatGreen(:, idx);
+        validMask = durations > 0;
+        durations = durations(validMask);
+        greenFlags = greenFlags(validMask);
+
+        if isempty(durations)
+            scheduleWindows = appendWindow(scheduleWindows, intersectionId, 0, horizonTime);
+            continue;
+        end
+
+        numPhases = numel(durations);
+        currentPhase = max(1, min(numPhases, currentPhase));
+
+        tCursor = 0;
+        remaining = timeRemaining;
+        if remaining <= 0
+            remaining = durations(currentPhase);
+        end
+
+        while tCursor < horizonTime
+            phaseEnd = tCursor + min(remaining, horizonTime - tCursor);
+            if greenFlags(currentPhase) > 0.5
+                scheduleWindows = appendWindow(scheduleWindows, intersectionId, tCursor, phaseEnd);
+            end
+
+            tCursor = tCursor + remaining;
+            if tCursor >= horizonTime
+                break;
+            end
+
+            currentPhase = mod(currentPhase, numPhases) + 1;
+            remaining = durations(currentPhase);
+            if remaining <= 0
+                break;
+            end
+        end
+    end
+end
+
+function scheduleWindows = appendWindow(scheduleWindows, intersectionId, startTime, endTime)
+%APPENDWINDOW Append a row describing a green window.
+    newRow = [intersectionId, startTime, endTime];
+    scheduleWindows = [scheduleWindows; newRow]; %#ok<AGROW>
+end

--- a/fuel_prediction_model.m
+++ b/fuel_prediction_model.m
@@ -1,0 +1,57 @@
+function FC = fuel_prediction_model(v, a, theta)
+%FUEL_PREDICTION_MODEL Estimate instantaneous fuel consumption rate.
+%   FC = fuel_prediction_model(v, a, theta) computes the instantaneous fuel
+%   consumption rate for the provided velocity (m/s), acceleration (m/s^2)
+%   and road grade (rad) using an experimentally tuned polynomial model.
+%
+%   The implementation follows the model described in the project README and
+%   supports scalar or vectorised inputs. All operations are performed using
+%   element-wise arithmetic to remain numerically stable when evaluated in
+%   MATLAB Function blocks inside Simulink.
+%
+%   See also: VELOCITYOPTIMIZ_DP.
+
+    arguments
+        v {mustBeReal}
+        a {mustBeReal, mustBeSizeCompatibleWith(v)}
+        theta {mustBeReal, mustBeSizeCompatibleWith(v)}
+    end
+
+    %% Vehicle parameters
+    rho = 1.2256;       % Air density (kg/m^3)
+    Cd = 0.615;         % Aerodynamic drag coefficient
+    Ch = 1 - 0.085 * 0; % Altitude correction coefficient (placeholder)
+    Af = 10.2;          % Frontal area (m^2)
+    Cr = 1.25;          % Rolling resistance coefficient
+    c1 = 0.0328;        % Rolling resistance speed coefficient 1
+    c2 = 4.575;         % Rolling resistance speed coefficient 2
+    mass = 23000;       % Vehicle mass (kg)
+    eta_d = 0.85;       % Drivetrain efficiency
+
+    %% 1. Driving resistances
+    R_drag = (rho/25.92) * Cd * Ch * Af .* (v.^2); % Aerodynamic drag
+    R_roll = 9.81 * (Cr/1000) .* (c1 .* v + c2);   % Rolling resistance
+    R_clm  = 9.81 * mass .* sin(theta);            % Climbing resistance
+    R = R_drag + R_roll + R_clm;                   % Total resistance
+
+    %% 2. Required power
+    P = ((R + 1.04 * mass .* a) ./ (3600 * eta_d)) .* v;
+
+    %% 3. Power-to-fuel conversion (quadratic model)
+    a0 = 0.7607578263;
+    a1 = 0.0336310284;
+    a2 = 0.0000630368;
+
+    FC_raw = a0 + a1 .* P + a2 .* (P.^2);
+
+    %% Final scaling
+    FC = FC_raw ./ 850;
+end
+
+function mustBeSizeCompatibleWith(x, y)
+%MUSTBESIZECOMPATIBLEWITH Ensure inputs can be broadcast together.
+    if ~isscalar(x) && ~isscalar(y) && ~isequal(size(x), size(y))
+        error("fuel_prediction_model:SizeMismatch", ...
+              "Inputs must be scalar or match in size.");
+    end
+end

--- a/initializeRouteQueue.m
+++ b/initializeRouteQueue.m
@@ -1,0 +1,24 @@
+function routeQueue = initializeRouteQueue(mapData)
+%INITIALIZEROUTEQUEUE Build a sorted queue of intersection descriptors.
+%   routeQueue = initializeRouteQueue(mapData) converts the intersection
+%   table provided in mapData into an ordered queue without using structs or
+%   cell arrays. Each row of mapData (and of the resulting queue) must
+%   contain:
+%       [intersectionId, cumulativeDistance, segmentLength, grade, speedLimit]
+%
+%   The intersections are sorted by the cumulative distance so that the
+%   first row corresponds to the closest upcoming intersection.
+
+    if isempty(mapData)
+        routeQueue = zeros(0, 5);
+        return;
+    end
+
+    if size(mapData, 2) < 5
+        error('initializeRouteQueue:InvalidMapData', ...
+              'mapData must have at least five columns.');
+    end
+
+    [~, order] = sort(mapData(:, 2));
+    routeQueue = mapData(order, 1:5);
+end

--- a/prepareOptimizationBuffer.m
+++ b/prepareOptimizationBuffer.m
@@ -1,0 +1,99 @@
+function [segments, segmentSteps, totalSteps, parameterVector, speedVector, spatBaseSel, spatDurSel, spatGreenSel] = ...
+    prepareOptimizationBuffer(routeQueue, horizonIndices, vehicleState, spatBase, spatDurations, spatGreen, speedGrid, options)
+%PREPAREOPTIMIZATIONBUFFER Assemble numeric inputs for the DP optimiser.
+%   This helper collects all required arrays while avoiding structs and
+%   cells. The output arguments are:
+%       segments        - Matrix describing the selected intersections.
+%       segmentSteps    - Row vector with discretisation steps per segment.
+%       totalSteps      - Total number of spatial steps.
+%       parameterVector - [ds, maxAccel, maxDecel, initialSpeed, travelledDistance, horizonTime].
+%       speedVector     - Candidate speed grid.
+%       spatBaseSel     - SPaT base information for the horizon intersections.
+%       spatDurSel      - Phase duration matrix aligned with spatBaseSel.
+%       spatGreenSel    - Phase green flags aligned with spatBaseSel.
+%
+%   routeQueue : Nx5 matrix from initializeRouteQueue.
+%   horizonIndices : row vector specifying which intersections are within the horizon.
+%   vehicleState : [currentSpeed; travelledDistance].
+%   spatBase : Mx3 matrix [id, currentPhase, timeToPhaseEnd].
+%   spatDurations : PxM matrix (duration per phase, columns align with spatBase rows).
+%   spatGreen : PxM matrix containing 0/1 flags for green availability.
+%   speedGrid : row vector of candidate speeds (optional).
+%   options : row vector [ds, maxAccel, maxDecel, horizonTime] (optional).
+
+    if isempty(horizonIndices)
+        segments = zeros(0, 5);
+        segmentSteps = zeros(1, 0);
+        totalSteps = 0;
+        parameterVector = zeros(1, 6);
+        speedVector = zeros(1, 0);
+        spatBaseSel = zeros(0, 3);
+        spatDurSel = zeros(0, 0);
+        spatGreenSel = zeros(0, 0);
+        return;
+    end
+
+    defaults = [10, 1.2, 1.5, 180];
+    if nargin < 8 || isempty(options)
+        opt = defaults;
+    else
+        opt = defaults;
+        opt(1:min(end, numel(options))) = options(1:min(end, numel(options)));
+    end
+
+    if nargin < 7 || isempty(speedGrid)
+        speedVector = 0:2:30;
+    else
+        speedVector = speedGrid(:)';
+    end
+
+    segments = routeQueue(horizonIndices, 1:5);
+    numSegments = size(segments, 1);
+
+    ds = opt(1);
+    segmentSteps = zeros(1, numSegments);
+    totalSteps = 0;
+    for idx = 1:numSegments
+        lengthValue = segments(idx, 3);
+        steps = max(1, round(lengthValue / ds));
+        segmentSteps(idx) = steps;
+        totalSteps = totalSteps + steps;
+    end
+
+    parameterVector = [ds, opt(2), opt(3), vehicleState(1), vehicleState(2), opt(4)];
+
+    [spatBaseSel, spatDurSel, spatGreenSel] = filterSpatForHorizon(spatBase, spatDurations, spatGreen, segments(:, 1));
+end
+
+function [spatBaseSel, spatDurSel, spatGreenSel] = filterSpatForHorizon(spatBase, spatDurations, spatGreen, segmentIds)
+%FILTERSPATFORHORIZON Filter SPaT tables for the selected intersections.
+%   The function returns empty matrices when any of the inputs are empty.
+
+    if isempty(spatBase) || isempty(spatDurations) || isempty(spatGreen)
+        spatBaseSel = zeros(0, 3);
+        spatDurSel = zeros(0, 0);
+        spatGreenSel = zeros(0, 0);
+        return;
+    end
+
+    numSegments = numel(segmentIds);
+    phases = size(spatDurations, 1);
+
+    spatBaseSel = zeros(numSegments, 3);
+    spatDurSel = zeros(phases, numSegments);
+    spatGreenSel = zeros(phases, numSegments);
+
+    for idx = 1:numSegments
+        intersectionId = segmentIds(idx);
+        match = find(spatBase(:, 1) == intersectionId, 1);
+        if isempty(match)
+            spatBaseSel(idx, :) = [intersectionId, 1, 0];
+            spatDurSel(:, idx) = zeros(phases, 1);
+            spatGreenSel(:, idx) = zeros(phases, 1);
+        else
+            spatBaseSel(idx, :) = spatBase(match, 1:3);
+            spatDurSel(:, idx) = spatDurations(:, match);
+            spatGreenSel(:, idx) = spatGreen(:, match);
+        end
+    end
+end

--- a/rhcSupervisor.m
+++ b/rhcSupervisor.m
@@ -1,0 +1,104 @@
+function [vSet, trajectorySpeeds, trajectoryTimes, diagVector] = rhcSupervisor(vehicleState, mapData, spatBase, spatDurations, spatGreen, speedGrid, options)
+%RHCSUPERVISOR Rolling horizon supervisor implemented with numeric arrays.
+%   [vSet, trajectorySpeeds, trajectoryTimes, diagVector] = rhcSupervisor(...)
+%   orchestrates the rolling horizon strategy described in the README
+%   without relying on structs or cell arrays. The inputs are:
+%       vehicleState : [currentSpeed; travelledDistance]
+%       mapData      : matrix with rows [id, distance, segmentLength, grade, speedLimit]
+%       spatBase     : matrix [id, currentPhase, timeToPhaseEnd]
+%       spatDurations: phase duration matrix (seconds)
+%       spatGreen    : phase green availability matrix (0/1)
+%       speedGrid    : optional candidate speed grid
+%       options      : optional vector [ds, maxAccel, maxDecel, horizonTime, reinitFlag]
+%
+%   Outputs:
+%       vSet            - target speed to apply in the next control interval
+%       trajectorySpeeds- row vector describing the optimal speed profile
+%       trajectoryTimes - arrival times associated with trajectorySpeeds
+%       diagVector      - diagnostic vector [currentIdx, firstHIdx, horizonCount, bestCost, penaltyCount]
+
+    persistent routeQueue currentIdx
+
+    if isempty(routeQueue)
+        routeQueue = zeros(0, 5);
+        currentIdx = 1;
+    end
+
+    if nargin < 7
+        options = [];
+    end
+
+    if isempty(vehicleState) || numel(vehicleState) < 2
+        error('rhcSupervisor:InvalidState', ...
+              'vehicleState must contain [currentSpeed; travelledDistance].');
+    end
+
+    reinitFlag = 0;
+    optVector = [];
+    if ~isempty(options)
+        if numel(options) >= 5
+            reinitFlag = options(5);
+            optVector = options(1:4);
+        else
+            optVector = options;
+        end
+    end
+
+    if isempty(routeQueue) || reinitFlag > 0.5
+        routeQueue = initializeRouteQueue(mapData);
+        currentIdx = 1;
+    end
+
+    if isempty(routeQueue)
+        vSet = vehicleState(1);
+        trajectorySpeeds = vehicleState(1);
+        trajectoryTimes = 0;
+        diagVector = [0, 0, 0, 0, 0];
+        return;
+    end
+
+    [horizonIndices, currentIdx] = updateHorizon(routeQueue, vehicleState, currentIdx);
+
+    if isempty(horizonIndices)
+        vSet = vehicleState(1);
+        trajectorySpeeds = zeros(1, 0);
+        trajectoryTimes = zeros(1, 0);
+        diagVector = [currentIdx, 0, 0, 0, 0];
+        routeQueue = zeros(0, 5);
+        currentIdx = 1;
+        return;
+    end
+
+    [segments, segmentSteps, totalSteps, parameterVector, speedVector, spatBaseSel, spatDurSel, spatGreenSel] = ...
+        prepareOptimizationBuffer(routeQueue, horizonIndices, vehicleState, spatBase, spatDurations, spatGreen, speedGrid, optVector);
+
+    if totalSteps <= 0 || isempty(segments)
+        vSet = vehicleState(1);
+        trajectorySpeeds = zeros(1, 0);
+        trajectoryTimes = zeros(1, 0);
+        diagVector = [currentIdx, horizonIndices(1), numel(horizonIndices), 0, 0];
+        return;
+    end
+
+    horizonTime = parameterVector(6);
+    signalWindows = fcn_stateless(spatBaseSel, spatDurSel, spatGreenSel, horizonTime);
+
+    [trajectorySpeeds, trajectoryTimes, dpInfo] = velocityOptimiz_DP(segments, segmentSteps, totalSteps, parameterVector, speedVector, signalWindows);
+
+    if isempty(trajectorySpeeds)
+        vSet = vehicleState(1);
+    else
+        if numel(trajectorySpeeds) >= 2
+            vSet = trajectorySpeeds(2);
+        else
+            vSet = trajectorySpeeds(1);
+        end
+    end
+
+    if isempty(dpInfo)
+        dpInfo = [0, 0, 0];
+    end
+
+    firstHIdx = horizonIndices(1);
+    diagVector = [currentIdx, firstHIdx, numel(horizonIndices), dpInfo(1), dpInfo(end)];
+end

--- a/rhc_pipeline.py
+++ b/rhc_pipeline.py
@@ -1,0 +1,604 @@
+"""Rolling horizon eco-driving pipeline implemented in Python.
+
+This module mirrors the MATLAB implementation shipped with the repository
+so that the algorithm can be exercised and tested directly in Python.
+The functions operate purely on NumPy arrays to stay close to the
+MATLAB numeric workflow and avoid struct- or cell-based data structures.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional, Tuple
+
+import numpy as np
+
+
+ArrayLike = np.ndarray
+
+
+@dataclass
+class RhcState:
+    """Mutable state for the rolling-horizon supervisor."""
+
+    route_queue: ArrayLike = field(default_factory=lambda: np.zeros((0, 5)))
+    current_idx: int = 0
+
+
+class RhcSupervisor:
+    """Python translation of the MATLAB ``rhcSupervisor`` function."""
+
+    def __init__(self) -> None:
+        self.state = RhcState()
+
+    def step(
+        self,
+        vehicle_state: ArrayLike,
+        map_data: ArrayLike,
+        spat_base: ArrayLike,
+        spat_durations: ArrayLike,
+        spat_green: ArrayLike,
+        speed_grid: Optional[ArrayLike] = None,
+        options: Optional[ArrayLike] = None,
+    ) -> Tuple[float, ArrayLike, ArrayLike, ArrayLike]:
+        """Execute a single rolling-horizon update.
+
+        Parameters correspond to the MATLAB implementation. ``options`` may
+        contain up to five elements ``[ds, maxAccel, maxDecel, horizonTime,
+        reinitFlag]``.
+        """
+
+        vehicle_state = np.asarray(vehicle_state, dtype=float).reshape(-1)
+        if vehicle_state.size < 2:
+            raise ValueError("vehicle_state must contain [currentSpeed, distance]")
+
+        reinit_flag = 0.0
+        opt_vector = np.asarray([], dtype=float)
+        if options is not None and len(options) > 0:
+            options = np.asarray(options, dtype=float).reshape(-1)
+            if options.size >= 5:
+                reinit_flag = float(options[4])
+                opt_vector = options[:4]
+            else:
+                opt_vector = options
+
+        if self.state.route_queue.size == 0 or reinit_flag > 0.5:
+            self.state.route_queue = initialize_route_queue(map_data)
+            self.state.current_idx = 0
+
+        if self.state.route_queue.size == 0:
+            v_current = float(vehicle_state[0])
+            return v_current, np.array([v_current]), np.array([0.0]), np.zeros(5)
+
+        horizon_indices, self.state.current_idx = update_horizon(
+            self.state.route_queue, vehicle_state, self.state.current_idx
+        )
+
+        if horizon_indices.size == 0:
+            v_current = float(vehicle_state[0])
+            self.state.route_queue = np.zeros((0, 5))
+            self.state.current_idx = 0
+            return v_current, np.zeros(0), np.zeros(0), np.array(
+                [self.state.current_idx, 0, 0, 0.0, 0.0], dtype=float
+            )
+
+        (
+            segments,
+            segment_steps,
+            total_steps,
+            parameter_vector,
+            speed_vector,
+            spat_base_sel,
+            spat_dur_sel,
+            spat_green_sel,
+        ) = prepare_optimization_buffer(
+            self.state.route_queue,
+            horizon_indices,
+            vehicle_state,
+            spat_base,
+            spat_durations,
+            spat_green,
+            speed_grid,
+            opt_vector,
+        )
+
+        if total_steps <= 0 or segments.size == 0:
+            v_current = float(vehicle_state[0])
+            return v_current, np.zeros(0), np.zeros(0), np.array(
+                [self.state.current_idx, horizon_indices[0], horizon_indices.size, 0.0, 0.0],
+                dtype=float,
+            )
+
+        horizon_time = float(parameter_vector[5])
+        signal_windows = fcn_stateless(
+            spat_base_sel, spat_dur_sel, spat_green_sel, horizon_time
+        )
+
+        (
+            trajectory_speeds,
+            trajectory_times,
+            dp_info,
+        ) = velocity_optimiz_dp(
+            segments,
+            segment_steps,
+            int(total_steps),
+            parameter_vector,
+            speed_vector,
+            signal_windows,
+        )
+
+        if trajectory_speeds.size == 0:
+            v_set = float(vehicle_state[0])
+        elif trajectory_speeds.size >= 2:
+            v_set = float(trajectory_speeds[1])
+        else:
+            v_set = float(trajectory_speeds[0])
+
+        if dp_info.size == 0:
+            dp_info = np.array([0.0, 0.0, 0.0])
+
+        diag_vector = np.array(
+            [
+                float(self.state.current_idx),
+                float(horizon_indices[0]),
+                float(horizon_indices.size),
+                float(dp_info[0]),
+                float(dp_info[-1]),
+            ]
+        )
+
+        return v_set, trajectory_speeds, trajectory_times, diag_vector
+
+
+def initialize_route_queue(map_data: ArrayLike) -> ArrayLike:
+    """Match the MATLAB ``initializeRouteQueue`` helper."""
+
+    map_data = np.asarray(map_data, dtype=float)
+    if map_data.size == 0:
+        return np.zeros((0, 5))
+    if map_data.shape[1] < 5:
+        raise ValueError("map_data must have at least five columns")
+
+    order = np.argsort(map_data[:, 1])
+    return map_data[order, :5]
+
+
+def update_horizon(
+    route_queue: ArrayLike, vehicle_state: ArrayLike, current_idx: int
+) -> Tuple[ArrayLike, int]:
+    """Replicate the MATLAB horizon selection routine."""
+
+    route_queue = np.asarray(route_queue, dtype=float)
+    vehicle_state = np.asarray(vehicle_state, dtype=float).reshape(-1)
+
+    if route_queue.size == 0:
+        return np.zeros(0, dtype=int), 0
+    if vehicle_state.size < 2:
+        raise ValueError("vehicle_state must contain [currentSpeed, distance]")
+
+    travelled_distance = float(vehicle_state[1])
+    num_intersections = route_queue.shape[0]
+
+    idx = max(0, int(current_idx))
+    while idx < num_intersections and travelled_distance >= route_queue[idx, 1] - 1e-3:
+        idx += 1
+
+    if idx >= num_intersections:
+        return np.zeros(0, dtype=int), idx
+
+    last_idx = min(num_intersections - 1, idx + 1)
+    horizon_indices = np.arange(idx, last_idx + 1, dtype=int)
+    return horizon_indices, idx
+
+
+def prepare_optimization_buffer(
+    route_queue: ArrayLike,
+    horizon_indices: ArrayLike,
+    vehicle_state: ArrayLike,
+    spat_base: ArrayLike,
+    spat_durations: ArrayLike,
+    spat_green: ArrayLike,
+    speed_grid: Optional[ArrayLike] = None,
+    options: Optional[ArrayLike] = None,
+) -> Tuple[ArrayLike, ArrayLike, int, ArrayLike, ArrayLike, ArrayLike, ArrayLike, ArrayLike]:
+    """Assemble DP inputs while staying close to the MATLAB variant."""
+
+    horizon_indices = np.asarray(horizon_indices, dtype=int)
+    if horizon_indices.size == 0:
+        return (
+            np.zeros((0, 5)),
+            np.zeros(0),
+            0,
+            np.zeros(6),
+            np.zeros(0),
+            np.zeros((0, 3)),
+            np.zeros((0, 0)),
+            np.zeros((0, 0)),
+        )
+
+    defaults = np.array([10.0, 1.2, 1.5, 180.0])
+    opt = defaults.copy()
+    if options is not None and len(options) > 0:
+        options = np.asarray(options, dtype=float).reshape(-1)
+        count = min(opt.size, options.size)
+        opt[:count] = options[:count]
+
+    if speed_grid is None or len(speed_grid) == 0:
+        speed_vector = np.arange(0.0, 30.0 + 1e-9, 2.0)
+    else:
+        speed_vector = np.asarray(speed_grid, dtype=float).reshape(-1)
+
+    segments = np.asarray(route_queue, dtype=float)[horizon_indices, :5]
+    num_segments = segments.shape[0]
+    ds = float(opt[0])
+
+    segment_steps = np.zeros(num_segments, dtype=int)
+    total_steps = 0
+    for idx in range(num_segments):
+        length_value = float(segments[idx, 2])
+        steps = max(1, int(round(length_value / ds)))
+        segment_steps[idx] = steps
+        total_steps += steps
+
+    vehicle_state = np.asarray(vehicle_state, dtype=float).reshape(-1)
+    parameter_vector = np.array(
+        [
+            ds,
+            float(opt[1]),
+            float(opt[2]),
+            float(vehicle_state[0]),
+            float(vehicle_state[1]),
+            float(opt[3]),
+        ]
+    )
+
+    (
+        spat_base_sel,
+        spat_dur_sel,
+        spat_green_sel,
+    ) = filter_spat_for_horizon(spat_base, spat_durations, spat_green, segments[:, 0])
+
+    return (
+        segments,
+        segment_steps,
+        int(total_steps),
+        parameter_vector,
+        speed_vector,
+        spat_base_sel,
+        spat_dur_sel,
+        spat_green_sel,
+    )
+
+
+def filter_spat_for_horizon(
+    spat_base: ArrayLike,
+    spat_durations: ArrayLike,
+    spat_green: ArrayLike,
+    segment_ids: ArrayLike,
+) -> Tuple[ArrayLike, ArrayLike, ArrayLike]:
+    """Helper that mirrors the MATLAB SPaT filtering routine."""
+
+    if (
+        spat_base is None
+        or spat_durations is None
+        or spat_green is None
+        or np.asarray(spat_base).size == 0
+        or np.asarray(spat_durations).size == 0
+        or np.asarray(spat_green).size == 0
+    ):
+        return np.zeros((0, 3)), np.zeros((0, 0)), np.zeros((0, 0))
+
+    spat_base = np.asarray(spat_base, dtype=float)
+    spat_durations = np.asarray(spat_durations, dtype=float)
+    spat_green = np.asarray(spat_green, dtype=float)
+    segment_ids = np.asarray(segment_ids, dtype=float).reshape(-1)
+
+    num_segments = segment_ids.size
+    phases = spat_durations.shape[0]
+
+    spat_base_sel = np.zeros((num_segments, 3))
+    spat_dur_sel = np.zeros((phases, num_segments))
+    spat_green_sel = np.zeros((phases, num_segments))
+
+    for idx, intersection_id in enumerate(segment_ids):
+        matches = np.where(np.isclose(spat_base[:, 0], intersection_id))[0]
+        if matches.size == 0:
+            spat_base_sel[idx, :] = np.array([intersection_id, 1.0, 0.0])
+            continue
+
+        match = matches[0]
+        spat_base_sel[idx, :] = spat_base[match, :3]
+        spat_dur_sel[:, idx] = spat_durations[:, match]
+        spat_green_sel[:, idx] = spat_green[:, match]
+
+    return spat_base_sel, spat_dur_sel, spat_green_sel
+
+
+def fcn_stateless(
+    spat_base: ArrayLike,
+    spat_durations: ArrayLike,
+    spat_green: ArrayLike,
+    horizon_time: float,
+) -> ArrayLike:
+    """Generate green windows for each intersection within the horizon."""
+
+    if horizon_time is None or horizon_time <= 0:
+        horizon_time = 180.0
+
+    if spat_base is None or np.asarray(spat_base).size == 0:
+        return np.zeros((0, 3))
+
+    spat_base = np.asarray(spat_base, dtype=float)
+    spat_durations = np.asarray(spat_durations, dtype=float)
+    spat_green = np.asarray(spat_green, dtype=float)
+
+    windows: list[list[float]] = []
+    for idx in range(spat_base.shape[0]):
+        intersection_id = float(spat_base[idx, 0])
+        current_phase = int(round(spat_base[idx, 1]))
+        time_remaining = float(spat_base[idx, 3 - 1])
+
+        durations = spat_durations[:, idx]
+        green_flags = spat_green[:, idx]
+        valid_mask = durations > 0
+        durations = durations[valid_mask]
+        green_flags = green_flags[valid_mask]
+
+        if durations.size == 0:
+            windows.append([intersection_id, 0.0, horizon_time])
+            continue
+
+        num_phases = durations.size
+        current_phase = max(1, min(num_phases, current_phase))
+
+        t_cursor = 0.0
+        remaining = time_remaining if time_remaining > 0 else float(durations[current_phase - 1])
+
+        while t_cursor < horizon_time and remaining > 0:
+            phase_end = min(horizon_time, t_cursor + remaining)
+            if green_flags[current_phase - 1] > 0.5:
+                windows.append([intersection_id, t_cursor, phase_end])
+
+            t_cursor += remaining
+            if t_cursor >= horizon_time:
+                break
+
+            current_phase = (current_phase % num_phases) + 1
+            remaining = float(durations[current_phase - 1])
+
+    if not windows:
+        return np.zeros((0, 3))
+
+    return np.asarray(windows, dtype=float)
+
+
+def velocity_optimiz_dp(
+    segments: ArrayLike,
+    segment_steps: ArrayLike,
+    total_steps: int,
+    parameter_vector: ArrayLike,
+    speed_vector: ArrayLike,
+    signal_windows: ArrayLike,
+) -> Tuple[ArrayLike, ArrayLike, ArrayLike]:
+    """Dynamic-programming eco-driving optimiser."""
+
+    if total_steps <= 0 or segments.size == 0:
+        return np.zeros(0), np.zeros(0), np.array([np.inf, 0.0, 0.0])
+
+    segments = np.asarray(segments, dtype=float)
+    segment_steps = np.asarray(segment_steps, dtype=int)
+    parameter_vector = np.asarray(parameter_vector, dtype=float)
+    speed_vector = np.asarray(speed_vector, dtype=float).reshape(-1)
+    signal_windows = np.asarray(signal_windows, dtype=float)
+
+    ds = float(parameter_vector[0])
+    max_accel = float(parameter_vector[1])
+    max_decel = float(parameter_vector[2])
+    initial_speed = float(parameter_vector[3])
+
+    if speed_vector.size == 0:
+        speeds = np.arange(0.0, 30.0 + 1e-9, 2.0)
+    else:
+        speeds = speed_vector
+    num_speeds = speeds.size
+
+    J = np.full((num_speeds, total_steps + 1), np.inf)
+    T = np.full((num_speeds, total_steps + 1), np.inf)
+    policy = np.zeros((num_speeds, total_steps), dtype=np.int32)
+
+    start_idx = int(np.argmin(np.abs(speeds - initial_speed)))
+    J[start_idx, 0] = 0.0
+    T[start_idx, 0] = 0.0
+
+    segment_boundary = np.cumsum(segment_steps)
+    grades = segments[:, 3]
+    limits = segments[:, 4]
+    step_grades = np.repeat(grades, segment_steps)
+    step_limits = np.repeat(limits, segment_steps)
+
+    if signal_windows.size == 0:
+        window_ids = np.zeros(0)
+        window_starts = np.zeros(0)
+        window_ends = np.zeros(0)
+    else:
+        window_ids = signal_windows[:, 0]
+        window_starts = signal_windows[:, 1]
+        window_ends = signal_windows[:, 2]
+
+    for step in range(total_steps):
+        grade = step_grades[step]
+        limit = step_limits[step]
+
+        for v_idx in range(num_speeds):
+            if not np.isfinite(J[v_idx, step]):
+                continue
+
+            v_current = speeds[v_idx]
+            t_current = T[v_idx, step]
+
+            for v_next_idx in range(num_speeds):
+                v_next = speeds[v_next_idx]
+                if v_next > limit + 1e-3:
+                    continue
+
+                accel = compute_acceleration(v_current, v_next, ds)
+                if accel > max_accel + 1e-6 or accel < -max_decel - 1e-6:
+                    continue
+
+                stage_time, feasible = compute_traversal_time(v_current, v_next, ds)
+                if not feasible:
+                    continue
+
+                t_arrival = t_current + stage_time
+                fuel_rate = fuel_prediction_model((v_current + v_next) / 2.0, accel, grade)
+                stage_cost = fuel_rate * stage_time
+
+                penalty = compute_signal_penalty(
+                    step,
+                    t_arrival,
+                    segment_boundary,
+                    segments[:, 0],
+                    window_ids,
+                    window_starts,
+                    window_ends,
+                )
+                total_cost = J[v_idx, step] + stage_cost + penalty
+
+                if total_cost + 1e-9 < J[v_next_idx, step + 1]:
+                    J[v_next_idx, step + 1] = total_cost
+                    T[v_next_idx, step + 1] = t_arrival
+                    policy[v_next_idx, step] = v_idx
+
+    terminal_idx = int(np.argmin(J[:, -1]))
+    best_cost = J[terminal_idx, -1]
+    if not np.isfinite(best_cost):
+        return np.zeros(0), np.zeros(0), np.array([np.inf, float(total_steps), float(segment_boundary.size)])
+
+    path_idx = np.zeros(total_steps + 1, dtype=int)
+    path_idx[-1] = terminal_idx
+    for step in range(total_steps - 1, -1, -1):
+        prev_idx = policy[path_idx[step + 1], step]
+        if prev_idx <= 0 and step != 0:
+            prev_idx = path_idx[step + 1]
+        path_idx[step] = prev_idx
+
+    trajectory_speeds = speeds[path_idx]
+    trajectory_times = np.array([T[path_idx[node], node] for node in range(total_steps + 1)])
+
+    penalty_count = evaluate_signal_compliance(
+        trajectory_times,
+        segment_boundary,
+        segments[:, 0],
+        window_ids,
+        window_starts,
+        window_ends,
+    )
+    dp_info = np.array([best_cost, float(total_steps), float(penalty_count)])
+
+    return trajectory_speeds, trajectory_times, dp_info
+
+
+def compute_acceleration(v_current: float, v_next: float, ds: float) -> float:
+    if ds <= 0:
+        raise ValueError("ds must be positive")
+    return (v_next**2 - v_current**2) / (2.0 * ds)
+
+
+def compute_traversal_time(v_current: float, v_next: float, ds: float) -> Tuple[float, bool]:
+    mean_speed = (v_current + v_next) / 2.0
+    if mean_speed <= 0:
+        return float("inf"), False
+    dt = ds / mean_speed
+    return float(dt), np.isfinite(dt) and dt > 0
+
+
+def compute_signal_penalty(
+    step: int,
+    arrival_time: float,
+    segment_boundary: ArrayLike,
+    segment_ids: ArrayLike,
+    window_ids: ArrayLike,
+    window_starts: ArrayLike,
+    window_ends: ArrayLike,
+) -> float:
+    if segment_boundary.size == 0 or window_ids.size == 0:
+        return 0.0
+
+    matches = np.where(segment_boundary == (step + 1))[0]
+    if matches.size == 0:
+        return 0.0
+
+    intersection_id = segment_ids[matches[0]]
+    mask = np.isclose(window_ids, intersection_id)
+    if not np.any(mask):
+        return 1e6
+
+    starts = window_starts[mask]
+    ends = window_ends[mask]
+    is_green = np.any((arrival_time >= starts) & (arrival_time <= ends))
+    if is_green:
+        return 0.0
+
+    time_to_green = np.min(np.abs(np.concatenate((starts, ends)) - arrival_time))
+    return 1e5 + 1e3 * float(time_to_green)
+
+
+def evaluate_signal_compliance(
+    trajectory_times: ArrayLike,
+    segment_boundary: ArrayLike,
+    segment_ids: ArrayLike,
+    window_ids: ArrayLike,
+    window_starts: ArrayLike,
+    window_ends: ArrayLike,
+) -> int:
+    if segment_boundary.size == 0:
+        return 0
+
+    penalty_count = 0
+    for idx, boundary in enumerate(segment_boundary):
+        step_index = int(boundary)
+        if step_index >= trajectory_times.size:
+            continue
+
+        arrival_time = trajectory_times[step_index]
+        intersection_id = segment_ids[idx]
+
+        mask = np.isclose(window_ids, intersection_id)
+        if not np.any(mask):
+            penalty_count += 1
+            continue
+
+        starts = window_starts[mask]
+        ends = window_ends[mask]
+        is_green = np.any((arrival_time >= starts) & (arrival_time <= ends))
+        if not is_green:
+            penalty_count += 1
+
+    return penalty_count
+
+
+def fuel_prediction_model(v: float, a: float, theta: float) -> float:
+    """Polynomial fuel consumption surrogate used by the DP solver."""
+
+    rho = 1.2256
+    cd = 0.615
+    ch = 1 - 0.085 * 0
+    af = 10.2
+    cr = 1.25
+    c1 = 0.0328
+    c2 = 4.575
+    mass = 23000
+    eta_d = 0.85
+
+    r_drag = (rho / 25.92) * cd * ch * af * (v**2)
+    r_roll = 9.81 * (cr / 1000.0) * (c1 * v + c2)
+    r_clm = 9.81 * mass * np.sin(theta)
+    resistance = r_drag + r_roll + r_clm
+
+    power = ((resistance + 1.04 * mass * a) / (3600.0 * eta_d)) * v
+
+    a0 = 0.7607578263
+    a1 = 0.0336310284
+    a2 = 0.0000630368
+
+    fc_raw = a0 + a1 * power + a2 * (power**2)
+    return fc_raw / 850.0

--- a/tests/test_rhc_pipeline.py
+++ b/tests/test_rhc_pipeline.py
@@ -1,0 +1,107 @@
+import pathlib
+import sys
+
+import numpy as np
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from rhc_pipeline import (
+    RhcSupervisor,
+    compute_acceleration,
+    compute_traversal_time,
+    fuel_prediction_model,
+    initialize_route_queue,
+    update_horizon,
+)
+
+
+def build_sample_inputs():
+    vehicle_state = np.array([12.0, 40.0])
+    map_data = np.array(
+        [
+            [1, 120, 60, 0.01, 18],
+            [2, 200, 80, 0.0, 20],
+            [3, 320, 90, -0.015, 22],
+        ]
+    )
+    spat_base = np.array(
+        [
+            [1, 2, 15],
+            [2, 1, 20],
+            [3, 3, 10],
+        ]
+    )
+    spat_durations = np.array(
+        [
+            [30, 25, 20],
+            [30, 35, 25],
+            [20, 40, 30],
+        ]
+    )
+    spat_green = np.array(
+        [
+            [1, 0, 0],
+            [0, 1, 1],
+            [1, 0, 1],
+        ]
+    )
+    return vehicle_state, map_data, spat_base, spat_durations, spat_green
+
+
+def test_initialize_route_queue_orders_by_distance():
+    _, map_data, *_ = build_sample_inputs()
+    queue = initialize_route_queue(map_data)
+    assert np.all(np.diff(queue[:, 1]) >= 0)
+
+
+def test_update_horizon_selects_two_intersections():
+    vehicle_state, map_data, *_ = build_sample_inputs()
+    queue = initialize_route_queue(map_data)
+    horizon, idx = update_horizon(queue, vehicle_state, 0)
+    assert horizon.size == 2
+    assert idx == horizon[0]
+
+
+def test_supervisor_runs_complete_cycle():
+    vehicle_state, map_data, spat_base, spat_durations, spat_green = build_sample_inputs()
+    supervisor = RhcSupervisor()
+    v_set, speeds, times, diag = supervisor.step(
+        vehicle_state,
+        map_data,
+        spat_base,
+        spat_durations,
+        spat_green,
+        options=[8.0, 1.5, 1.8, 160.0, 1.0],
+    )
+
+    assert isinstance(v_set, float)
+    assert speeds.ndim == 1 and times.ndim == 1
+    assert speeds.size == times.size
+    assert diag.size == 5
+
+    # Call again without reinitialisation to ensure horizon progress is tracked.
+    vehicle_state_followup = np.array([speeds[0] if speeds.size else 10.0, 150.0])
+    v_set_2, speeds_2, times_2, diag_2 = supervisor.step(
+        vehicle_state_followup,
+        map_data,
+        spat_base,
+        spat_durations,
+        spat_green,
+        options=[8.0, 1.5, 1.8, 160.0, 0.0],
+    )
+    assert isinstance(v_set_2, float)
+    assert diag_2[0] >= diag[0]
+    assert speeds_2.size == times_2.size
+
+
+def test_low_level_utilities_behave_reasonably():
+    accel = compute_acceleration(10.0, 12.0, 5.0)
+    assert accel > 0
+
+    dt, feasible = compute_traversal_time(10.0, 12.0, 5.0)
+    assert feasible and dt > 0
+
+    fc = fuel_prediction_model(10.0, accel, 0.01)
+    assert fc > 0

--- a/updateHorizon.m
+++ b/updateHorizon.m
@@ -1,0 +1,45 @@
+function [horizonIndices, currentIdx] = updateHorizon(routeQueue, vehicleState, currentIdx)
+%UPDATEHORIZON Determine the active prediction horizon.
+%   [horizonIndices, currentIdx] = updateHorizon(routeQueue, vehicleState,
+%   currentIdx) selects the next two intersections that fall within the
+%   rolling horizon. The function operates purely on numeric arrays.
+%
+%   routeQueue : Nx5 matrix returned by initializeRouteQueue.
+%   vehicleState : [currentSpeed; travelledDistance].
+%   currentIdx : current pointer into routeQueue (scalar index).
+%
+%   horizonIndices : row vector containing the indices of the intersections
+%                    that form the optimisation horizon (up to two).
+
+    horizonIndices = zeros(1, 0);
+
+    if isempty(routeQueue)
+        currentIdx = 1;
+        return;
+    end
+
+    if isempty(vehicleState) || numel(vehicleState) < 2
+        error('updateHorizon:InvalidState', ...
+              'vehicleState must contain [currentSpeed; travelledDistance].');
+    end
+
+    travelledDistance = vehicleState(2);
+    numIntersections = size(routeQueue, 1);
+
+    if currentIdx < 1
+        currentIdx = 1;
+    end
+
+    while currentIdx <= numIntersections && ...
+          travelledDistance >= routeQueue(currentIdx, 2) - 1e-3
+        currentIdx = currentIdx + 1;
+    end
+
+    if currentIdx > numIntersections
+        horizonIndices = zeros(1, 0);
+        return;
+    end
+
+    lastIdx = min(numIntersections, currentIdx + 1);
+    horizonIndices = currentIdx:lastIdx;
+end

--- a/velocityOptimiz_DP.m
+++ b/velocityOptimiz_DP.m
@@ -1,0 +1,206 @@
+function [trajectorySpeeds, trajectoryTimes, dpInfo] = velocityOptimiz_DP(segments, segmentSteps, totalSteps, parameterVector, speedVector, signalWindows)
+%VELOCITYOPTIMIZ_DP Dynamic programming eco-driving optimiser without structs.
+%   [trajectorySpeeds, trajectoryTimes, dpInfo] = velocityOptimiz_DP(...)
+%   computes the minimum-fuel trajectory using only numeric arrays.
+%
+%   segments       : matrix where each row is [id, distance, length, grade, speedLimit].
+%   segmentSteps   : row vector with discretisation steps per segment.
+%   totalSteps     : total number of spatial steps across the horizon.
+%   parameterVector: [ds, maxAccel, maxDecel, initialSpeed, travelledDistance, horizonTime].
+%   speedVector    : candidate speed grid (row vector).
+%   signalWindows  : matrix with rows [intersectionId, startTime, endTime].
+%
+%   Outputs:
+%       trajectorySpeeds - optimal speed profile (row vector).
+%       trajectoryTimes  - cumulative arrival times (row vector).
+%       dpInfo           - [bestCost, totalSteps, penaltyCount].
+
+    if totalSteps <= 0 || isempty(segments)
+        trajectorySpeeds = zeros(1, 0);
+        trajectoryTimes = zeros(1, 0);
+        dpInfo = [inf, 0, 0];
+        return;
+    end
+
+    ds = parameterVector(1);
+    maxAccel = parameterVector(2);
+    maxDecel = parameterVector(3);
+    initialSpeed = parameterVector(4);
+
+    if isempty(speedVector)
+        speeds = 0:2:30;
+    else
+        speeds = speedVector(:)';
+    end
+    numSpeeds = numel(speeds);
+
+    J = inf(numSpeeds, totalSteps + 1);
+    T = inf(numSpeeds, totalSteps + 1);
+    policy = zeros(numSpeeds, totalSteps, 'uint16');
+
+    [~, startIdx] = min(abs(speeds - initialSpeed));
+    J(startIdx, 1) = 0;
+    T(startIdx, 1) = 0;
+
+    segmentBoundary = cumsum(segmentSteps);
+    grades = segments(:, 4)';
+    limits = segments(:, 5)';
+    stepGrades = repelem(grades, segmentSteps);
+    stepLimits = repelem(limits, segmentSteps);
+
+    windowIds = signalWindows(:, 1);
+    windowStarts = signalWindows(:, 2);
+    windowEnds = signalWindows(:, 3);
+
+    for step = 1:totalSteps
+        grade = stepGrades(step);
+        limit = stepLimits(step);
+
+        for vIdx = 1:numSpeeds
+            if ~isfinite(J(vIdx, step))
+                continue;
+            end
+
+            vCurrent = speeds(vIdx);
+            tCurrent = T(vIdx, step);
+
+            for vNextIdx = 1:numSpeeds
+                vNext = speeds(vNextIdx);
+                if vNext > limit + 1e-3
+                    continue;
+                end
+
+                accel = computeAcceleration(vCurrent, vNext, ds);
+                if accel > maxAccel + 1e-6 || accel < -maxDecel - 1e-6
+                    continue;
+                end
+
+                [stageTime, feasible] = computeTraversalTime(vCurrent, vNext, ds);
+                if ~feasible
+                    continue;
+                end
+
+                tArrival = tCurrent + stageTime;
+                fuelRate = fuel_prediction_model((vCurrent + vNext) / 2, accel, grade);
+                stageCost = fuelRate * stageTime;
+
+                penalty = computeSignalPenalty(step, tArrival, segmentBoundary, segments(:, 1), windowIds, windowStarts, windowEnds);
+                totalCost = J(vIdx, step) + stageCost + penalty;
+
+                if totalCost + 1e-9 < J(vNextIdx, step + 1)
+                    J(vNextIdx, step + 1) = totalCost;
+                    T(vNextIdx, step + 1) = tArrival;
+                    policy(vNextIdx, step) = uint16(vIdx);
+                end
+            end
+        end
+    end
+
+    [bestCost, terminalIdx] = min(J(:, end));
+    if ~isfinite(bestCost)
+        trajectorySpeeds = zeros(1, 0);
+        trajectoryTimes = zeros(1, 0);
+        dpInfo = [inf, totalSteps, numel(segmentBoundary)];
+        return;
+    end
+
+    pathIdx = zeros(totalSteps + 1, 1);
+    pathIdx(end) = terminalIdx;
+    for step = totalSteps:-1:1
+        prevIdx = policy(pathIdx(step + 1), step);
+        if prevIdx == 0
+            prevIdx = pathIdx(step + 1);
+        end
+        pathIdx(step) = prevIdx;
+    end
+
+    trajectorySpeeds = speeds(pathIdx)';
+    trajectoryTimes = zeros(1, totalSteps + 1);
+    for node = 1:(totalSteps + 1)
+        trajectoryTimes(node) = T(pathIdx(node), node);
+    end
+
+    penaltyCount = evaluateSignalCompliance(trajectoryTimes, segmentBoundary, segments(:, 1), windowIds, windowStarts, windowEnds);
+    dpInfo = [bestCost, totalSteps, penaltyCount];
+end
+
+function accel = computeAcceleration(vCurrent, vNext, ds)
+%COMPUTEACCELERATION Estimate acceleration using spatial discretisation.
+    if ds <= 0
+        error('velocityOptimiz_DP:InvalidStep', 'ds must be positive.');
+    end
+    accel = (vNext^2 - vCurrent^2) / (2 * ds);
+end
+
+function [dt, feasible] = computeTraversalTime(vCurrent, vNext, ds)
+%COMPUTETRAVERSALTIME Compute travel time between two speed states.
+    meanSpeed = (vCurrent + vNext) / 2;
+    if meanSpeed <= 0
+        dt = inf;
+        feasible = false;
+        return;
+    end
+    dt = ds / meanSpeed;
+    feasible = isfinite(dt) && dt > 0;
+end
+
+function penalty = computeSignalPenalty(step, arrivalTime, segmentBoundary, segmentIds, windowIds, windowStarts, windowEnds)
+%COMPUTESIGNALPENALTY Apply a soft penalty if the vehicle arrives on red.
+    penalty = 0;
+    if isempty(segmentBoundary) || isempty(windowIds)
+        return;
+    end
+
+    boundaryIndex = find(step == segmentBoundary, 1);
+    if isempty(boundaryIndex)
+        return;
+    end
+
+    intersectionId = segmentIds(boundaryIndex);
+    mask = windowIds == intersectionId;
+
+    if ~any(mask)
+        penalty = 1e6;
+        return;
+    end
+
+    starts = windowStarts(mask);
+    ends = windowEnds(mask);
+    isGreen = any(arrivalTime >= starts & arrivalTime <= ends);
+
+    if ~isGreen
+        timeToGreen = min(abs([starts(:); ends(:)] - arrivalTime));
+        penalty = 1e5 + 1e3 * timeToGreen;
+    end
+end
+
+function penaltyCount = evaluateSignalCompliance(trajectoryTimes, segmentBoundary, segmentIds, windowIds, windowStarts, windowEnds)
+%EVALUATESIGNALCOMPLIANCE Count how many intersections are violated.
+    penaltyCount = 0;
+    if isempty(segmentBoundary)
+        return;
+    end
+
+    numBoundaries = numel(segmentBoundary);
+    for idx = 1:numBoundaries
+        stepIndex = segmentBoundary(idx);
+        if stepIndex + 1 > numel(trajectoryTimes)
+            continue;
+        end
+        arrivalTime = trajectoryTimes(stepIndex + 1);
+        intersectionId = segmentIds(idx);
+
+        mask = windowIds == intersectionId;
+        if ~any(mask)
+            penaltyCount = penaltyCount + 1;
+            continue;
+        end
+
+        starts = windowStarts(mask);
+        ends = windowEnds(mask);
+        isGreen = any(arrivalTime >= starts & arrivalTime <= ends);
+        if ~isGreen
+            penaltyCount = penaltyCount + 1;
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- translate the rolling-horizon supervisor and helpers into a Python module that mirrors the MATLAB workflow with NumPy arrays
- implement the DP eco-driving solver, SPaT filtering, and fuel model to enable end-to-end execution in Python
- add pytest-based checks for queue ordering, horizon selection, supervisor execution, and low-level utilities

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfd62113588333a6c138de83e393c4